### PR TITLE
divider row bg colour preview fix

### DIFF
--- a/print.css
+++ b/print.css
@@ -1,2 +1,3 @@
 body {margin: 0mm 0mm 0mm 0mm;font-family: sans-serif;}
 table {font-size: x-small;width: 100%; border-collapse: collapse; margin-top: 0rem;} th, td {border-top: black 1px solid; padding: 2px; vertical-align: top;}
+tr.divider-row {background-color: #f5f5f5 !important;print-color-adjust: exact;font-weight: bold;font-size: 20px;}


### PR DESCRIPTION
Added `print-color-adjust: exact;` to print css